### PR TITLE
Update redhat.yaml

### DIFF
--- a/vars/redhat.yaml
+++ b/vars/redhat.yaml
@@ -1,8 +1,7 @@
 ---
 packages:
-  - libselinux-python
+  - python3-libselinux
   - mc
-  - python2-openstackclient
   - firewalld
   - openssh-server
   - cronie


### PR DESCRIPTION
- python2-openstackclient is not available on Centos 8
- added python3 libselinux package